### PR TITLE
Fix regular expression syntax

### DIFF
--- a/cookbooks/eydr/recipes/default.rb
+++ b/cookbooks/eydr/recipes/default.rb
@@ -31,7 +31,7 @@ end
 # Failover section
 if node[:failover] && node[:ec2][:public_hostname] == node[:dr_replication][node[:environment][:framework_env]][:slave][:public_hostname]
   if db_master? || solo?
-    include_recipe "eydr::#{node['engineyard']['environment']['db_stack_name'].split(/[0..9]/).first}_failover"
+    include_recipe "eydr::#{node['engineyard']['environment']['db_stack_name'].split(/[0-9]/).first}_failover"
   end
 
   if node[:dns_failover][:enabled] && app_master?


### PR DESCRIPTION
This code is failing because `[0..9]` matches the characters '0', '.',
and '9'. This breaks when the stack name is 'mysql5_5', because it tries
to load 'eydr::mysql5_5_failover' instead of 'eydr::mysql_failover'.

Change the regular expression to be `[0-9]` which correctly matches the
numbers 0 through 9. It will properly split the name of the recipe
and correctly load 'eydr::mysql_failover'
